### PR TITLE
fix: closing pre tag

### DIFF
--- a/lib/eleventy-plugin-plantuml.js
+++ b/lib/eleventy-plugin-plantuml.js
@@ -72,7 +72,7 @@ const plugin = (eleventyConfig, pluginOptions = {}) => {
       return highlighter(diagram, language);
     }
     // default highlighter just in case
-    return `<pre class="${language}">${diagram}</a>`;
+    return `<pre class="${language}">${diagram}</pre>`;
   });
   return {};
 };


### PR DESCRIPTION
The `<pre>` tag is not closed, and there is a `</a>` closing tag